### PR TITLE
Update PluginBase.java

### DIFF
--- a/src/main/java/cn/nukkit/plugin/PluginBase.java
+++ b/src/main/java/cn/nukkit/plugin/PluginBase.java
@@ -174,7 +174,7 @@ abstract public class PluginBase implements Plugin {
     }
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+    public boolean onCommand(CommandSender sender, Command command, String[] args) {
         return false;
     }
 


### PR DESCRIPTION
Removing unused label in onCommand, can be replaced by command.getName(); (most used)